### PR TITLE
Update nest_filter_balance.R

### DIFF
--- a/R/nest_filter_balance.R
+++ b/R/nest_filter_balance.R
@@ -79,7 +79,7 @@ nest_filt_bal <- function(test, y, x,
   out <- list(ytrain = ytrain, ytest = ytest,
               filt_xtrain = filt_xtrain, filt_xtest = filt_xtest,
               filt_pen.factor = filt_pen.factor)
-  if (modifyX_useY) out$modify_fit <- modfit
+  if (modifyX & modifyX_useY) out$modify_fit <- modfit
   out
 }
 

--- a/R/nest_filter_balance.R
+++ b/R/nest_filter_balance.R
@@ -79,7 +79,7 @@ nest_filt_bal <- function(test, y, x,
   out <- list(ytrain = ytrain, ytest = ytest,
               filt_xtrain = filt_xtrain, filt_xtest = filt_xtest,
               filt_pen.factor = filt_pen.factor)
-  if (modifyX & modifyX_useY) out$modify_fit <- modfit
+  if (!is.null(modifyX) & modifyX_useY) out$modify_fit <- modfit
   out
 }
 


### PR DESCRIPTION
in 
`if (modifyX_useY) out$modify_fit <- modfit`
check if `modifyX==T `too. 
This way, `modifyX_useY = TRUE` will be ignored when `modifyX=FALSE`.
This is useful when you compare the two approaces using a grid and adding `modifyX_useY=T` to the ... of the comparison function. 