### PR TITLE
axis ticks aesthetics

### DIFF
--- a/R/shap.R
+++ b/R/shap.R
@@ -161,6 +161,7 @@ plot_shap_beeswarm <- function(shap, x,
     xlab("SHAP value") +
     theme_classic() +
     theme(axis.text = element_text(colour = "black"),
+          axis.ticks = element_line(color = "black"),
           legend.title = element_text(angle = 90, hjust = 0.5, vjust = 0,
                                                        size = rel(0.9)))
 }
@@ -224,6 +225,7 @@ plot_shap_bar <- function(shap, x,
     xlab("mean(|SHAP|)") +
     ylab("") +
     theme_classic() +
-    theme(axis.text = element_text(colour = "black"))
+    theme(axis.text = element_text(colour = "black"),
+          axis.ticks = element_line(color = "black"))
 }
 


### PR DESCRIPTION
axis ticks for theme_classic are black.

plots with theme_minimal left untouched because no axis border and so is redundant in these instances.